### PR TITLE
fix: SVG logo in Safari

### DIFF
--- a/brand/logo/black/FTCLib-black.svg
+++ b/brand/logo/black/FTCLib-black.svg
@@ -15,31 +15,22 @@
 			--color-ftc: black;
 			--color-lib: black;
 			--outline-thickness: 2px;
-			--corner-radius-mean: 100%;
 		}
 
-		rect{
+		circle{
 			--center-flag: 0;
 			--center-offset: 2px;
 			--center-mean: 64px;
 			--center: calc(var(--center-mean) - var(--center-flag)*var(--center-offset));
-			--corner: calc(var(--center) - var(--radius));
-			x: var(--corner);
-			y: var(--corner);
+			cx: var(--center);
+			cy: var(--center);
 
 			--radius-flag: 0;
 			--radius-mean: 51px;
-			--radius-offset-magnitude: 9px;
-			--radius-offset: calc(var(--radius-flag)*var(--radius-offset-magnitude));
-			--radius: calc(var(--radius-mean) + var(--radius-offset));
+			--radius-offset: 9px;
+			--radius: calc(var(--radius-mean) + var(--radius-flag)*var(--radius-offset));
 
-			--corner-radius: calc( var(--corner-radius-mean) + var(--radius-offset) );
-			rx: var(--corner-radius);
-			ry: var(--corner-radius);
-
-			--diameter: calc(2*var(--radius));
-			width: var(--diameter);
-			height: var(--diameter);
+			r: var(--radius);
 		}
 
 		.bottom {
@@ -65,7 +56,7 @@
 		}
 
 		.solid {
-			stroke-width: calc(var(--radius-offset-magnitude)*2)
+			stroke-width: calc(var(--radius-offset)*2)
 		}
 
 		.outlined {
@@ -75,15 +66,15 @@
 
 	</style>
 
-	<rect fill='var(--color-theme)'/>
+	<circle fill='var(--color-theme)'/>
 
-	<rect class='solid bottom ring'/>
-	<rect class='outlined outer bottom ring'/>
-	<rect class='outlined inner bottom ring'/>
+	<circle class='solid bottom ring'/>
+	<circle class='outlined outer bottom ring'/>
+	<circle class='outlined inner bottom ring'/>
 
-	<rect class='solid top ring'/>
-	<rect class='outlined outer top ring'/>
-	<rect class='outlined inner top ring'/>
+	<circle class='solid top ring'/>
+	<circle class='outlined outer top ring'/>
+	<circle class='outlined inner top ring'/>
 
 	<path class='outlined' fill='var(--color-triangle)' d='
 			M 62 6.2

--- a/brand/logo/color/FTCLib.svg
+++ b/brand/logo/color/FTCLib.svg
@@ -18,14 +18,13 @@
 			--corner-radius-mean: 100%;
 		}
 
-		rect{
+		circle{
 			--center-flag: 0;
 			--center-offset: 2px;
 			--center-mean: 64px;
 			--center: calc(var(--center-mean) - var(--center-flag)*var(--center-offset));
-			--corner: calc(var(--center) - var(--radius));
-			x: var(--corner);
-			y: var(--corner);
+			cx: var(--center);
+			cy: var(--center);
 
 			--radius-flag: 0;
 			--radius-mean: 51px;
@@ -33,13 +32,9 @@
 			--radius-offset: calc(var(--radius-flag)*var(--radius-offset-magnitude));
 			--radius: calc(var(--radius-mean) + var(--radius-offset));
 
-			--corner-radius: calc( var(--corner-radius-mean) + var(--radius-offset) );
-			rx: var(--corner-radius);
-			ry: var(--corner-radius);
+			r: var(--radius);
 
 			--diameter: calc(2*var(--radius));
-			width: var(--diameter);
-			height: var(--diameter);
 		}
 
 		.bottom {
@@ -75,15 +70,15 @@
 
 	</style>
 
-	<rect fill='var(--color-theme)'/>
+	<circle fill='var(--color-theme)'/>
 
-	<rect class='solid bottom ring'/>
-	<rect class='outlined outer bottom ring'/>
-	<rect class='outlined inner bottom ring'/>
+	<circle class='solid bottom ring'/>
+	<circle class='outlined outer bottom ring'/>
+	<circle class='outlined inner bottom ring'/>
 
-	<rect class='solid top ring'/>
-	<rect class='outlined outer top ring'/>
-	<rect class='outlined inner top ring'/>
+	<circle class='solid top ring'/>
+	<circle class='outlined outer top ring'/>
+	<circle class='outlined inner top ring'/>
 
 	<path class='outlined' fill='var(--color-triangle)' d='
 			M 62 6.2

--- a/brand/logo/color/FTCLib.svg
+++ b/brand/logo/color/FTCLib.svg
@@ -1,3 +1,4 @@
+
 <svg width='128' height='128' viewBox='0 0 128 128' xmlns='http://www.w3.org/2000/svg' stroke-linejoin='round'>
 
 	<title>Logo of FTCLib</title>
@@ -15,7 +16,6 @@
 			--color-ftc: white;
 			--color-lib: black;
 			--outline-thickness: 2px;
-			--corner-radius-mean: 100%;
 		}
 
 		circle{
@@ -28,13 +28,9 @@
 
 			--radius-flag: 0;
 			--radius-mean: 51px;
-			--radius-offset-magnitude: 9px;
-			--radius-offset: calc(var(--radius-flag)*var(--radius-offset-magnitude));
-			--radius: calc(var(--radius-mean) + var(--radius-offset));
-
+			--radius-offset: 9px;
+			--radius: calc(var(--radius-mean) + var(--radius-flag)*var(--radius-offset));
 			r: var(--radius);
-
-			--diameter: calc(2*var(--radius));
 		}
 
 		.bottom {
@@ -60,7 +56,7 @@
 		}
 
 		.solid {
-			stroke-width: calc(var(--radius-offset-magnitude)*2)
+			stroke-width: calc(var(--radius-offset)*2)
 		}
 
 		.outlined {

--- a/brand/logo/grayscale/FTCLib-grayscale.svg
+++ b/brand/logo/grayscale/FTCLib-grayscale.svg
@@ -15,31 +15,21 @@
 			--color-ftc: white;
 			--color-lib: black;
 			--outline-thickness: 2px;
-			--corner-radius-mean: 100%;
 		}
 
-		rect{
+		circle{
 			--center-flag: 0;
 			--center-offset: 2px;
 			--center-mean: 64px;
 			--center: calc(var(--center-mean) - var(--center-flag)*var(--center-offset));
-			--corner: calc(var(--center) - var(--radius));
-			x: var(--corner);
-			y: var(--corner);
+			cx: var(--center);
+			cy: var(--center);
 
 			--radius-flag: 0;
 			--radius-mean: 51px;
-			--radius-offset-magnitude: 9px;
-			--radius-offset: calc(var(--radius-flag)*var(--radius-offset-magnitude));
-			--radius: calc(var(--radius-mean) + var(--radius-offset));
-
-			--corner-radius: calc( var(--corner-radius-mean) + var(--radius-offset) );
-			rx: var(--corner-radius);
-			ry: var(--corner-radius);
-
-			--diameter: calc(2*var(--radius));
-			width: var(--diameter);
-			height: var(--diameter);
+			--radius-offset: 9px;
+			--radius: calc(var(--radius-mean) + var(--radius-flag)*var(--radius-offset));
+			r: var(--radius);
 		}
 
 		.bottom {
@@ -65,7 +55,7 @@
 		}
 
 		.solid {
-			stroke-width: calc(var(--radius-offset-magnitude)*2)
+			stroke-width: calc(var(--radius-offset)*2)
 		}
 
 		.outlined {
@@ -75,15 +65,15 @@
 
 	</style>
 
-	<rect fill='var(--color-theme)'/>
+	<circle fill='var(--color-theme)'/>
 
-	<rect class='solid bottom ring'/>
-	<rect class='outlined outer bottom ring'/>
-	<rect class='outlined inner bottom ring'/>
+	<circle class='solid bottom ring'/>
+	<circle class='outlined outer bottom ring'/>
+	<circle class='outlined inner bottom ring'/>
 
-	<rect class='solid top ring'/>
-	<rect class='outlined outer top ring'/>
-	<rect class='outlined inner top ring'/>
+	<circle class='solid top ring'/>
+	<circle class='outlined outer top ring'/>
+	<circle class='outlined inner top ring'/>
 
 	<path class='outlined' fill='var(--color-triangle)' d='
 			M 62 6.2


### PR DESCRIPTION
Rectangles to circles, hopefully. Haven't tested in Safari yet but I'm assuming it at least supports specifying the radius in CSS.