### PR TITLE
MotorEx Calls Super At Constructor

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 ext {
     PUBLISH_GROUP_ID = 'com.arcrobotics'
     PUBLISH_ARTIFACT_ID = 'ftclib'
-    PUBLISH_VERSION = '1.1.3'
+    PUBLISH_VERSION = '1.1.4'
 }
 
 android {
@@ -17,7 +17,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 1
-        versionName 'v1.1.2'
+        versionName 'v1.1.4'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -169,7 +169,7 @@ public class Motor implements HardwareDevice {
         BRAKE(DcMotor.ZeroPowerBehavior.BRAKE),
         FLOAT(DcMotor.ZeroPowerBehavior.UNKNOWN);
 
-        private DcMotor.ZeroPowerBehavior m_behavior;
+        private final DcMotor.ZeroPowerBehavior m_behavior;
 
         ZeroPowerBehavior(DcMotor.ZeroPowerBehavior behavior) {
             m_behavior = behavior;
@@ -198,10 +198,10 @@ public class Motor implements HardwareDevice {
      */
     protected GoBILDA type;
 
-    protected PIDController veloController;
-    protected PController positionController;
+    protected PIDController veloController = new PIDController(1,0,0);;
+    protected PController positionController = new PController(1);
 
-    protected SimpleMotorFeedforward feedforward;
+    protected SimpleMotorFeedforward feedforward = new SimpleMotorFeedforward(0, 1, 0);
 
     private boolean targetIsSet = false;
 
@@ -218,9 +218,6 @@ public class Motor implements HardwareDevice {
         runmode = RunMode.RawPower;
         type = GoBILDA.NONE;
         ACHIEVABLE_MAX_TICKS_PER_SECOND = motor.getMotorType().getAchieveableMaxTicksPerSecond();
-        veloController = new PIDController(1,0,0);
-        positionController = new PController(1);
-        feedforward = new SimpleMotorFeedforward(0, 1, 0);
         encoder = new Encoder(motor::getCurrentPosition);
     }
 
@@ -236,9 +233,6 @@ public class Motor implements HardwareDevice {
         runmode = RunMode.RawPower;
         type = gobildaType;
         ACHIEVABLE_MAX_TICKS_PER_SECOND = gobildaType.getAchievableMaxTicksPerSecond();
-        veloController = new PIDController(1,0,0);
-        positionController = new PController(1);
-        feedforward = new SimpleMotorFeedforward(0, 1, 0);
         encoder = new Encoder(motor::getCurrentPosition);
     }
 
@@ -255,9 +249,6 @@ public class Motor implements HardwareDevice {
         runmode = RunMode.RawPower;
         type = GoBILDA.NONE;
         ACHIEVABLE_MAX_TICKS_PER_SECOND = cpr * rpm / 60;
-        veloController = new PIDController(1,0,0);
-        positionController = new PController(1);
-        feedforward = new SimpleMotorFeedforward(0, 1, 0);
         encoder = new Encoder(motor::getCurrentPosition);
     }
 
@@ -282,9 +273,10 @@ public class Motor implements HardwareDevice {
     /**
      * Sets the distance per pulse of the encoder in units per tick.
      * @param distancePerPulse  the desired distance per pulse
+     * @return an encoder an object with the specified distance per pulse
      */
-    public void setDistancePerPulse(double distancePerPulse) {
-        encoder.setDistancePerPulse(distancePerPulse);
+    public Encoder setDistancePerPulse(double distancePerPulse) {
+        return encoder.setDistancePerPulse(distancePerPulse);
     }
 
     /**

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
@@ -43,14 +43,8 @@ public class MotorEx extends Motor {
      * @param gobildaType the type of gobilda 5202 series motor being used
      */
     public MotorEx(@NonNull HardwareMap hMap, String id, @NonNull GoBILDA gobildaType) {
-        motorEx = hMap.get(DcMotorEx.class, id);
-        runmode = RunMode.RawPower;
-        type = gobildaType;
-        ACHIEVABLE_MAX_TICKS_PER_SECOND = gobildaType.getAchievableMaxTicksPerSecond();
-        veloController = new PIDController(1,0,0);
-        positionController = new PController(1);
-        feedforward = new SimpleMotorFeedforward(0, 1, 0);
-        encoder = new Encoder(motorEx::getCurrentPosition);
+        super(hMap, id, gobildaType);
+        motorEx = (DcMotorEx)hMap.get(DcMotor.class, id);
     }
 
     /**
@@ -62,14 +56,8 @@ public class MotorEx extends Motor {
      * @param rpm       the revolutions per minute of the motor
      */
     public MotorEx(@NonNull HardwareMap hMap, String id, double cpr, double rpm) {
-        motor = hMap.get(DcMotorEx.class, id);
-        runmode = RunMode.RawPower;
-        type = GoBILDA.NONE;
-        ACHIEVABLE_MAX_TICKS_PER_SECOND = cpr * rpm / 60;
-        veloController = new PIDController(1,0,0);
-        positionController = new PController(1);
-        feedforward = new SimpleMotorFeedforward(0, 1, 0);
-        encoder = new Encoder(motor::getCurrentPosition);
+        super(hMap, id, cpr, rpm);
+        motorEx = (DcMotorEx)hMap.get(DcMotor.class, id);
     }
 
     @Override

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ JavaDocs - <https://javadoc.io/doc/com.arcrobotics/ftclib/1.1.1/index.html>
 
     ```groovy
     dependencies {
-        implementation 'com.arcrobotics:ftclib:1.1.3'
+        implementation 'com.arcrobotics:ftclib:1.1.4'
         // the following is optional if you want vision
         implementation 'com.arcrobotics.ftclib:vision:1.1.0'
     }


### PR DESCRIPTION
# MotorEx Calls Super At Constructor

## What kind of change does this PR introduce?
* Fix - fixes #112 ; uses `super()` in the constructor and pre-initializes default controllers

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__