### PR TITLE
Improve LUT

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/util/LUT.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/util/LUT.java
@@ -1,12 +1,12 @@
 package com.arcrobotics.ftclib.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A lookup table
  */
-public class LUT<T extends Number, R> extends HashMap<T, R> {
+public class LUT<T extends Number, R> extends TreeMap<T, R> {
 
     public void add(T key, R out) {
         put(key, out);
@@ -19,16 +19,21 @@ public class LUT<T extends Number, R> extends HashMap<T, R> {
      * @return the closest value to the input key
      */
     public R getClosest(T key) {
-        T closest = key;
-        double diff = Double.POSITIVE_INFINITY;
-        for (Map.Entry<T, R> entry : entrySet()) {
-            double dif = Math.abs(entry.getKey().doubleValue() - key.doubleValue());
-            if (dif <= diff) {
-                diff = dif;
-                closest = entry.getKey();
-            }
+        Map.Entry<T, R> ceil = ceilingEntry(key);
+        Map.Entry<T, R> floor = floorEntry(key);
+
+        if (ceil != null && floor != null) {
+            double keyVal = key.doubleValue();
+            double ceilDiff = Math.abs(ceil.getKey().doubleValue() - keyVal);
+            double floorDiff = Math.abs(floor.getKey().doubleValue() - keyVal);
+            return floorDiff < ceilDiff ? floor.getValue() : ceil.getValue();
+        } else if (ceil != null) {
+            return ceil.getValue();
+        } else if (floor != null) {
+            return floor.getValue();
+        } else {
+            return null;
         }
-        return get(closest);
     }
 
 }

--- a/core/src/test/java/com/arcrobotics/ftclib/util/LUTTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/util/LUTTest.java
@@ -1,0 +1,25 @@
+package com.arcrobotics.ftclib.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LUTTest {
+    @Test
+    public void getClosest() {
+        LUT<Double, Integer> lut = new LUT<>();
+        lut.add(0.0, 0);
+        lut.add(1.0, 1);
+        lut.add(2.0, 2);
+
+        for (int i = 0; i < 50; i++) {
+            double d = Math.random() * 2.5; // generate number in range [0, 2.5)
+            assertEquals(Math.round(d), lut.getClosest(d).intValue());
+        }
+    }
+
+    @Test
+    public void empty() {
+        assertNull(new LUT<Integer, Integer>().getClosest(0));
+    }
+}


### PR DESCRIPTION
# Improve LUT

This is a pretty small PR. The existing implementation does a linear search through all the entries in the map to find the closest key, which wastes all the benefits of using a map. This changes it to use a TreeMap, so finding the closest entry can be done in logarithmic time.

## What kind of change does this PR introduce?
* Fix - Improved performance
* Feature - Added LUT unit test

## Did this PR introduce a breaking change?
* No, it doesn't change the contract of LUT, it just improves the performance