### PR TITLE
Fix timer bugs

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/util/Timing.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/util/Timing.java
@@ -58,12 +58,14 @@ public class Timing {
          * Pauses this timer. While the timer is paused, elapsedTime() and remainingTime() will not change.
          */
         public void pause() {
-            pauseTime = time.nanoseconds();
-            timerOn = false;
+            if (timerOn) {
+                pauseTime = time.nanoseconds();
+                timerOn = false;
+            }
         }
 
         /**
-         * Resumes this timer if it is paused.
+         * Resumes this timer if it is running and paused.
          */
         public void resume() {
             if (!timerOn) {
@@ -74,9 +76,11 @@ public class Timing {
         }
 
         /**
-         * Get the elapsed time since this time was started. If it was not started, return 0.
+         * Get the elapsed time since this time was started.
          *
          * @return The elapsed time, in the units specified in the constructor.
+         * If the timer was not started, return 0.
+         * If the timer is paused, return the time at which the timer was paused.
          */
         public long elapsedTime() {
             if (timerOn) return time.time(unit);
@@ -84,9 +88,11 @@ public class Timing {
         }
 
         /**
-         * Get the remaining time until this timer is done. If it was not started, returns the timer length.
+         * Get the remaining time until this timer is done.
          *
          * @return The remaining time, in the units specified in the constructor.
+         * If it was not started, returns the timer length.
+         * If it was paused, return the remaining time at the time the timer was paused.
          */
         public long remainingTime() {
             return timerLength - elapsedTime();
@@ -95,7 +101,7 @@ public class Timing {
         /**
          * Check if this timer has finished.
          *
-         * @return True if at least timerLength time has elapsed since the start of this timer. False otherwise.
+         * @return True if at least timerLength of unpaused time has elapsed since the start of this timer. False otherwise.
          */
         public boolean done() {
             return elapsedTime() >= timerLength;

--- a/core/src/main/java/com/arcrobotics/ftclib/util/Timing.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/util/Timing.java
@@ -12,61 +12,109 @@ public class Timing {
     /**
      * Class for a timer. This can be used for checking if a duration has passed, only continuing
      * if the timer has finished, and so forth.
-     *
+     * <p>
      * A more simple version of a timer better suited for quick uses rather than an
-     *  {@link ElapsedTime} object.
+     * {@link ElapsedTime} object.
      */
     public static class Timer {
         private ElapsedTime time;
         private long timerLength;
-        private long pauseTime;
+        private long pauseTime; // in nanoseconds, regardless of unit
         private TimeUnit unit;
         private boolean timerOn;
 
-        /**Creates a timer with the given length and unit. */
+        /**
+         * Creates a new timer object.
+         *
+         * @param timerLength The length of the timer, in the units specified by unit.
+         * @param unit        The unit of timerLength.
+         */
         public Timer(long timerLength, TimeUnit unit) {
             this.timerLength = timerLength;
             this.unit = unit;
             this.time = new ElapsedTime();
-        }
-
-        /** Creates a timer with the given length and a unit of seconds. */
-        public Timer(long timerLength){
-            this.timerLength = timerLength;
-            this.unit = TimeUnit.SECONDS;
-            this.time = new ElapsedTime();
-        }
-
-        public void start(){
             time.reset();
+        }
+
+        /**
+         * Creates a new timer object.
+         *
+         * @param timerLength The length of the timer, in seconds.
+         */
+        public Timer(long timerLength) {
+            this(timerLength, TimeUnit.SECONDS);
+        }
+
+        /**
+         * Starts this timer.
+         */
+        public void start() {
+            time.reset();
+            pauseTime = 0;
             timerOn = true;
         }
 
-        public void pause(){
-            pauseTime = time.now(unit);
+        /**
+         * Pauses this timer. While the timer is paused, elapsedTime() and remainingTime() will not change.
+         */
+        public void pause() {
+            pauseTime = time.nanoseconds();
             timerOn = false;
         }
 
-        public void resume(){
-            time = new ElapsedTime(pauseTime);
-            timerOn = true;
+        /**
+         * Resumes this timer if it is paused.
+         */
+        public void resume() {
+            if (!timerOn) {
+                // we start the timer with a time in the past, since we're starting in the middle of the timer
+                time = new ElapsedTime(System.nanoTime() - pauseTime);
+                timerOn = true;
+            }
         }
 
-        public long currentTime(){
-            if(timerOn) return time.now(unit);
-            else return 0;
+        /**
+         * Get the elapsed time since this time was started. If it was not started, return 0.
+         *
+         * @return The elapsed time, in the units specified in the constructor.
+         */
+        public long elapsedTime() {
+            if (timerOn) return time.time(unit);
+            else return unit.convert(pauseTime, TimeUnit.NANOSECONDS);
         }
 
-        public boolean done(){
-            return currentTime() >= timerLength;
+        /**
+         * Get the remaining time until this timer is done. If it was not started, returns the timer length.
+         *
+         * @return The remaining time, in the units specified in the constructor.
+         */
+        public long remainingTime() {
+            return timerLength - elapsedTime();
         }
 
-        public boolean isTimerOn() { return timerOn;}
+        /**
+         * Check if this timer has finished.
+         *
+         * @return True if at least timerLength time has elapsed since the start of this timer. False otherwise.
+         */
+        public boolean done() {
+            return elapsedTime() >= timerLength;
+        }
+
+        /**
+         * Check if this timer is running.
+         *
+         * @return True if this timer has been started and is not paused, false otherwise.
+         */
+        public boolean isTimerOn() {
+            return timerOn;
+        }
     }
 
-    /**Very simple class for a refresh rate timer. Can be used to limit hardware writing/reading,
-     * or other fast-time cases. Only uses milliseconds. Starts counting on creation, can be reset. */
-
+    /**
+     * Very simple class for a refresh rate timer. Can be used to limit hardware writing/reading,
+     * or other fast-time cases. Only uses milliseconds. Starts counting on creation, can be reset.
+     */
     public class Rate {
 
         private ElapsedTime time;
@@ -77,11 +125,11 @@ public class Timing {
             time = new ElapsedTime(ElapsedTime.Resolution.MILLISECONDS);
         }
 
-        public void reset(){
+        public void reset() {
             time.reset();
         }
 
-        public boolean atTime(){
+        public boolean atTime() {
             boolean done = (time.milliseconds() >= rate);
             time.reset();
             return done;

--- a/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
@@ -1,0 +1,87 @@
+package com.arcrobotics.ftclib.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static com.arcrobotics.ftclib.util.Timing.*;
+
+public class TimingTest {
+    private Timer timer;
+    private final int seconds = 3;
+
+    private void assertElapsedWithin(long minMillis, long margin, Runnable runnable) {
+        Thread curr = Thread.currentThread();
+        Thread interrupt = new Thread(() -> {
+            try {
+                Thread.sleep(minMillis + margin);
+                curr.interrupt();
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        });
+        interrupt.start();
+        long start = System.currentTimeMillis();
+        runnable.run();
+        interrupt.interrupt();
+        long end = System.currentTimeMillis();
+        assertTrue(end - start >= minMillis);
+    }
+
+    @BeforeEach
+    public void reset() {
+        timer = new Timer(seconds, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void startAtZeroTest() {
+        assertEquals(0, timer.elapsedTime());
+    }
+
+    @Test
+    public void pauseTest() throws InterruptedException {
+        timer.start();
+        Thread.sleep(1000);
+        timer.pause();
+        long currTime = timer.elapsedTime();
+        assertTrue(currTime >= 1);
+        Thread.sleep(500);
+        assertEquals(currTime, timer.elapsedTime());
+    }
+
+    @Test
+    public void pauseResumeTest() throws InterruptedException {
+        int sleepTime = 1000;
+        int margin = 150;
+        timer.start();
+        Thread.sleep(sleepTime);
+        timer.pause();
+        Thread.sleep(1000);
+        // assert that the remaining timer action happens in between 1850-2150ms
+        // (this accounts for imperfect time slices)
+        assertElapsedWithin(seconds * 1000 - sleepTime - margin, 2 * margin, () -> {
+            timer.resume();
+            while (!timer.done()) {
+                Thread.yield();
+            }
+        });
+    }
+
+    @Test
+    public void elapsedTimeTest() {
+        boolean[] success = new boolean[1];
+        assertElapsedWithin(seconds * 1000, 1500, () -> {
+            timer.start();
+            while (!Thread.interrupted()) {
+                if (timer.done()) {
+                    success[0] = true;
+                    break;
+                }
+                Thread.yield();
+            }
+        });
+        assertTrue(success[0]);
+    }
+}

--- a/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
@@ -12,6 +12,14 @@ public class TimingTest {
     private Timer timer;
     private final int seconds = 3;
 
+    /**
+     * Assert that the supplied runnable runs for between minMillis and minMillis+margin milliseconds.
+     *
+     * @param minMillis The minimum amount of time in which the runnable should run, in ms.
+     * @param margin    The difference between the minimum and maximum time in which the runnable should run.
+     *                  This is to account for inaccuracies in cpu time slices.
+     * @param runnable  The runnable to run. This should include the timing and waiting code.
+     */
     private void assertElapsedWithin(long minMillis, long margin, Runnable runnable) {
         Thread curr = Thread.currentThread();
         Thread interrupt = new Thread(() -> {

--- a/examples/src/main/java/com/example/ftclibexamples/OldCommandSample/SimpleLinearLift.java
+++ b/examples/src/main/java/com/example/ftclibexamples/OldCommandSample/SimpleLinearLift.java
@@ -1,6 +1,5 @@
 package com.example.ftclibexamples.OldCommandSample;
 
-import com.arcrobotics.ftclib.hardware.motors.Motor;
 import com.arcrobotics.ftclib.hardware.motors.MotorEx;
 import com.arcrobotics.ftclib.util.Direction;
 import com.arcrobotics.ftclib.util.Timing;
@@ -36,7 +35,7 @@ public class SimpleLinearLift {
         int multiplier = direction == Direction.UP ? 1 : -1;
 
         while (!timer.done()) {
-            m_liftMotor.set(multiplier * (activeTime - timer.currentTime()) / (double)activeTime);
+            m_liftMotor.set(multiplier * (activeTime - timer.elapsedTime()) / (double)activeTime);
         }
     }
 


### PR DESCRIPTION
# Fix timer

The timer class seemed to be broken. The `ElapsedTime` class has pretty ambiguous documentation, so the `Timer` class wasn't using it correctly. This meant that a lot of the behavior of the timer class was incorrect. The pause and resume functionality was incorrect, and so was the functionality to track elapsed time.

The `currentTime()` method was a little ambiguous as well (is it counting up from 0, or counting down from `timerLength`?) so I renamed it to `elapsedTime()` and added a `remainingTime()`.

## What kind of change does this PR introduce?
* Fix
* Feature

## Did this PR introduce a breaking change?
* Unless some code relied on broken behavior, this shouldn't break anything