### PR TITLE
Fix Pause Test For Timer

### DIFF
--- a/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/util/TimingTest.java
@@ -51,7 +51,7 @@ public class TimingTest {
     @Test
     public void pauseTest() throws InterruptedException {
         timer.start();
-        Thread.sleep(1000);
+        Thread.sleep(1005);
         timer.pause();
         long currTime = timer.elapsedTime();
         assertTrue(currTime >= 1);


### PR DESCRIPTION
# Fix Pause Test for Timer

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Fix - the issue was the thread was slept for 1 second but the timer might not have reached that 1 second mark yet when the timer is then paused. When calling `.elapsedTime()` this will return 0 because the timer is in seconds, which returns a long. Since it is less than 1, it was truncated to 0, so it was not `>= 1`. So, I increased the sleep time by 5 milliseconds to ensure the timer pauses at that point.

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__