### PR TITLE
Change EOCV Version to 1.4.2

### DIFF
--- a/core/src/test/java/com/arcrobotics/ftclib/command/CommandSchedulerTests.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/command/CommandSchedulerTests.java
@@ -113,6 +113,26 @@ public class CommandSchedulerTests {
         CommandScheduler.getInstance().reset();
     }
 
+    @Test
+    public void testDefaultCommand() {
+        x = 3;
+        Robot.enable();
+        SubsystemBase p = new SubsystemBase() {
+            @Override
+            public void periodic() {
+                x = 3;
+            }
+        };
+        p.setDefaultCommand(new PerpetualCommand(new InstantCommand(() -> x = 5, p)));
+        CommandScheduler.getInstance().schedule(new InstantCommand(() -> x = 3, p));
+        assertEquals(3, x);
+        CommandScheduler.getInstance().run();
+        assertEquals(5, x);
+        CommandScheduler.getInstance().schedule(new PerpetualCommand(new InstantCommand(() -> x = 3, p)));
+        CommandScheduler.getInstance().run();
+        assertEquals(3, x);
+    }
+
     public boolean getValue() {
         return val;
     }

--- a/core/vision/build.gradle
+++ b/core/vision/build.gradle
@@ -5,14 +5,14 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven'
 
 dependencies {
-    api 'org.openftc:easyopencv:1.4.1'
+    api 'org.openftc:easyopencv:1.4.2'
     implementation "androidx.core:core-ktx:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 def groupId = 'com.arcrobotics.ftclib'
 def artifactId = 'vision'
-def version = '1.1.0'
+def version = '1.2.0'
 
 def localReleaseDest = "${buildDir}/release/${version}"
 def releaseStorageDir = "${projectDir}/ReleaseStorage"

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ JavaDocs - <https://javadoc.io/doc/com.arcrobotics/ftclib/1.1.1/index.html>
     dependencies {
         implementation 'com.arcrobotics:ftclib:1.2.0'
         // the following is optional if you want vision
-        implementation 'com.arcrobotics.ftclib:vision:1.1.0'
+        implementation 'com.arcrobotics.ftclib:vision:1.2.0'
     }
     ```
 6. Because FTCLib makes use of advanced features, you need to increase the minSdkVersion to 24. Unfortunately, this means that ZTE Speed Phones are not supported in this release.


### PR DESCRIPTION
# Change EOCV Version to 1.4.2

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Other - change version of EOCV to v1.4.2

I also changed the vision version from 1.1.0 to 1.2.0 for the next release.

## Did this PR introduce a breaking change?
Not for FTCLib - all changes can be found in the [EOCV changelog](https://github.com/OpenFTC/EasyOpenCV#v142).

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__