### PR TITLE
Revert Value Reading and Add Read Method to GamepadEx

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/gamepad/ButtonReader.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/gamepad/ButtonReader.java
@@ -40,25 +40,21 @@ public class ButtonReader implements KeyReader {
 
     /** Checks if the button is down **/
     public boolean isDown() {
-        readValue();
         return buttonState.getAsBoolean();
     }
 
     /** Checks if the button was just pressed **/
     public boolean wasJustPressed() {
-        readValue();
         return (!lastState && currState);
     }
 
     /** Checks if the button was just released **/
     public boolean wasJustReleased() {
-        readValue();
         return (lastState && !currState);
     }
 
     /** Checks if the button state has changed **/
     public boolean stateJustChanged() {
-        readValue();
         return (lastState != currState);
     }
 

--- a/core/src/main/java/com/arcrobotics/ftclib/gamepad/GamepadEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/gamepad/GamepadEx.java
@@ -164,6 +164,16 @@ public class GamepadEx {
     }
 
     /**
+     * Updates the value for each {@link ButtonReader}.
+     * Call this once in your loop.
+     */
+    public void readButtons() {
+        for (Button button : buttons) {
+            buttonReaders.get(button).readValue();
+        }
+    }
+
+    /**
      * Returns if the button is down
      *
      * @param button    the desired button to read from

--- a/core/src/main/java/com/arcrobotics/ftclib/gamepad/TriggerReader.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/gamepad/TriggerReader.java
@@ -41,25 +41,21 @@ public class TriggerReader implements KeyReader {
 
     /** Checks if the button is down **/
     public boolean isDown() {
-        readValue();
         return currState;
     }
 
     /** Checks if the button was just pressed **/
     public boolean wasJustPressed() {
-        readValue();
         return (!lastState && currState);
     }
 
     /** Checks if the button was just released **/
     public boolean wasJustReleased() {
-        readValue();
         return (lastState && !currState);
     }
 
     /** Checks if the button state has changed **/
     public boolean stateJustChanged() {
-        readValue();
         return (lastState != currState);
     }
 

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/ServoEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/ServoEx.java
@@ -18,7 +18,7 @@ public interface ServoEx extends HardwareDevice {
     /**
      * Rotates the servo by a certain angle in degrees.
      *
-     * @param angle The desired angle of rotation in degrees
+     * @param degrees The desired angle of rotation in degrees
      */
     void rotateByAngle(double degrees);
 
@@ -33,7 +33,7 @@ public interface ServoEx extends HardwareDevice {
     /**
      * Turns the servo position to a set angle in degrees.
      *
-     * @param angle The desired set position of the servo in degrees
+     * @param degrees The desired set position of the servo in degrees
      */
     void turnToAngle(double degrees);
 

--- a/core/src/test/java/com/arcrobotics/ftclib/gamepad/GamepadButtonTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/gamepad/GamepadButtonTest.java
@@ -53,10 +53,16 @@ public class GamepadButtonTest {
         BooleanSupplier wasJustPressed = () -> gamepadEx.wasJustPressed(GamepadKeys.Button.A);
         assertFalse(wasJustPressed.getAsBoolean());
         myGamepad.a = true;
+        assertFalse(wasJustPressed.getAsBoolean());
+        gamepadEx.readButtons();
         assertTrue(wasJustPressed.getAsBoolean());
         myGamepad.a = true;
+        assertTrue(wasJustPressed.getAsBoolean());
+        gamepadEx.readButtons();
         assertFalse(wasJustPressed.getAsBoolean());
         myGamepad.a = false;
+        assertFalse(wasJustPressed.getAsBoolean());
+        gamepadEx.readButtons();
         assertFalse(wasJustPressed.getAsBoolean());
     }
 

--- a/examples/src/main/java/com/example/ftclibexamples/GamepadSample.java
+++ b/examples/src/main/java/com/example/ftclibexamples/GamepadSample.java
@@ -33,6 +33,7 @@ public class GamepadSample extends LinearOpMode {
                 && toolOp.wasJustPressed(GamepadKeys.Button.B);
         waitForStart();
         while (opModeIsActive()) {
+            toolOp.readButtons();
             if (openClaw.getAsBoolean()) {
                 grip.setPosition(1);
             }


### PR DESCRIPTION
# Efficient Gamepad

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Feature - makes the use of readers more efficient to use only one value read per loop (reverts the change made in #109) and adds a single `readButtons()` method to `GamepadEx` to read all button values at once

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__