### PR TITLE
Fix Target Position For Non-Default Distance Per Pulse

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 ext {
     PUBLISH_GROUP_ID = 'com.arcrobotics'
     PUBLISH_ARTIFACT_ID = 'ftclib'
-    PUBLISH_VERSION = '1.2.0-beta'
+    PUBLISH_VERSION = '1.2.0'
 }
 
 android {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 ext {
     PUBLISH_GROUP_ID = 'com.arcrobotics'
     PUBLISH_ARTIFACT_ID = 'ftclib'
-    PUBLISH_VERSION = '1.2.0'
+    PUBLISH_VERSION = '1.2.0-beta'
 }
 
 android {

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -205,7 +205,6 @@ public class Motor implements HardwareDevice {
     protected SimpleMotorFeedforward feedforward = new SimpleMotorFeedforward(0, 1, 0);
 
     private boolean targetIsSet = false;
-    private boolean targetIsDistance = false;
 
     public Motor() {}
 
@@ -265,7 +264,7 @@ public class Motor implements HardwareDevice {
             double velocity = veloController.calculate(getVelocity(), speed) + feedforward.calculate(speed);
             motor.setPower(velocity / ACHIEVABLE_MAX_TICKS_PER_SECOND);
         } else if (runmode == RunMode.PositionControl) {
-            double error = positionController.calculate(targetIsDistance ? encoder.getDistance() : encoder.getPosition());
+            double error = positionController.calculate(getDistance());
             motor.setPower(output * error);
         } else {
             motor.setPower(output);
@@ -396,8 +395,7 @@ public class Motor implements HardwareDevice {
      * @param target    the target position in ticks
      */
     public void setTargetPosition(int target) {
-        setTargetDistance((double)target / (encoder.dpp));
-        targetIsDistance = false;
+        setTargetDistance(target * encoder.dpp);
     }
 
     /**
@@ -409,7 +407,6 @@ public class Motor implements HardwareDevice {
      */
     public void setTargetDistance(double target) {
         targetIsSet = true;
-        targetIsDistance = true;
         positionController.setSetPoint(target);
     }
 


### PR DESCRIPTION
# Fix Target Position For Non-Default Distance Per Pulse

After testing the target distance calculation, there was a mistake in the math. It should have been multiplying by distance per pulse instead of dividing, to get the correct distance target. Since the target position method uses the target distance method, tracking whether the target is distance or not is useless.

## What kind of change does this PR introduce?
* Fix

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__