### PR TITLE
Improve MotorEx Velocity and Motor Configuration Type

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -368,6 +368,9 @@ public class Motor implements HardwareDevice {
     }
 
     public void setBuffer(double fraction) {
+        if (fraction <= 0 || fraction > 1) {
+            throw new IllegalArgumentException("Buffer must be between 0 and 1, exclusive to 0");
+        }
         bufferFraction = fraction;
     }
 

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -9,6 +9,7 @@ import com.arcrobotics.ftclib.hardware.HardwareDevice;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.configuration.typecontainers.MotorConfigurationType;
 
 import java.util.function.Supplier;
 
@@ -220,6 +221,9 @@ public class Motor implements HardwareDevice {
         motor = hMap.get(DcMotor.class, id);
         runmode = RunMode.RawPower;
         type = GoBILDA.NONE;
+        MotorConfigurationType type = motor.getMotorType().clone();
+        type.setAchieveableMaxRPMFraction(1.0);
+        motor.setMotorType(type);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = motor.getMotorType().getAchieveableMaxTicksPerSecond();
         encoder = new Encoder(motor::getCurrentPosition);
     }
@@ -235,6 +239,9 @@ public class Motor implements HardwareDevice {
         motor = hMap.get(DcMotor.class, id);
         runmode = RunMode.RawPower;
         type = gobildaType;
+        MotorConfigurationType type = motor.getMotorType().clone();
+        type.setAchieveableMaxRPMFraction(1.0);
+        motor.setMotorType(type);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = gobildaType.getAchievableMaxTicksPerSecond();
         encoder = new Encoder(motor::getCurrentPosition);
     }
@@ -251,6 +258,9 @@ public class Motor implements HardwareDevice {
         motor = hMap.get(DcMotor.class, id);
         runmode = RunMode.RawPower;
         type = GoBILDA.NONE;
+        MotorConfigurationType type = motor.getMotorType().clone();
+        type.setAchieveableMaxRPMFraction(1.0);
+        motor.setMotorType(type);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = cpr * rpm / 60;
         encoder = new Encoder(motor::getCurrentPosition);
     }

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -218,14 +218,8 @@ public class Motor implements HardwareDevice {
      * @param id   the device id from the RC config
      */
     public Motor(@NonNull HardwareMap hMap, String id) {
-        motor = hMap.get(DcMotor.class, id);
-        runmode = RunMode.RawPower;
-        type = GoBILDA.NONE;
-        MotorConfigurationType type = motor.getMotorType().clone();
-        type.setAchieveableMaxRPMFraction(1.0);
-        motor.setMotorType(type);
+        this(hMap, id, GoBILDA.NONE);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = motor.getMotorType().getAchieveableMaxTicksPerSecond();
-        encoder = new Encoder(motor::getCurrentPosition);
     }
 
     /**
@@ -237,13 +231,15 @@ public class Motor implements HardwareDevice {
      */
     public Motor(@NonNull HardwareMap hMap, String id, @NonNull GoBILDA gobildaType) {
         motor = hMap.get(DcMotor.class, id);
+        encoder = new Encoder(motor::getCurrentPosition);
+
         runmode = RunMode.RawPower;
         type = gobildaType;
+
         MotorConfigurationType type = motor.getMotorType().clone();
         type.setAchieveableMaxRPMFraction(1.0);
         motor.setMotorType(type);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = gobildaType.getAchievableMaxTicksPerSecond();
-        encoder = new Encoder(motor::getCurrentPosition);
     }
 
     /**
@@ -255,14 +251,8 @@ public class Motor implements HardwareDevice {
      * @param rpm  the revolutions per minute of the motor
      */
     public Motor(@NonNull HardwareMap hMap, String id, double cpr, double rpm) {
-        motor = hMap.get(DcMotor.class, id);
-        runmode = RunMode.RawPower;
-        type = GoBILDA.NONE;
-        MotorConfigurationType type = motor.getMotorType().clone();
-        type.setAchieveableMaxRPMFraction(1.0);
-        motor.setMotorType(type);
+        this(hMap, id, GoBILDA.NONE);
         ACHIEVABLE_MAX_TICKS_PER_SECOND = cpr * rpm / 60;
-        encoder = new Encoder(motor::getCurrentPosition);
     }
 
     /**

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
@@ -60,7 +60,7 @@ public class MotorEx extends Motor {
     @Override
     public void set(double output) {
         if (runmode == RunMode.VelocityControl) {
-            double speed = output * ACHIEVABLE_MAX_TICKS_PER_SECOND;
+            double speed = bufferFraction * output * ACHIEVABLE_MAX_TICKS_PER_SECOND;
             double velocity = veloController.calculate(getCorrectedVelocity(), speed) + feedforward.calculate(speed);
             motorEx.setPower(velocity / ACHIEVABLE_MAX_TICKS_PER_SECOND);
         } else if (runmode == RunMode.PositionControl) {

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorEx.java
@@ -41,7 +41,7 @@ public class MotorEx extends Motor {
      */
     public MotorEx(@NonNull HardwareMap hMap, String id, @NonNull GoBILDA gobildaType) {
         super(hMap, id, gobildaType);
-        motorEx = (DcMotorEx) hMap.get(DcMotor.class, id);
+        motorEx = (DcMotorEx) super.motor;
     }
 
     /**
@@ -54,7 +54,7 @@ public class MotorEx extends Motor {
      */
     public MotorEx(@NonNull HardwareMap hMap, String id, double cpr, double rpm) {
         super(hMap, id, cpr, rpm);
-        motorEx = (DcMotorEx) hMap.get(DcMotor.class, id);
+        motorEx = (DcMotorEx) super.motor;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class MotorEx extends Motor {
         if (runmode == RunMode.VelocityControl) {
             double speed = output * ACHIEVABLE_MAX_TICKS_PER_SECOND;
             double velocity = veloController.calculate(getCorrectedVelocity(), speed) + feedforward.calculate(speed);
-            setVelocity(velocity);
+            motorEx.setPower(velocity / ACHIEVABLE_MAX_TICKS_PER_SECOND);
         } else if (runmode == RunMode.PositionControl) {
             double error = positionController.calculate(encoder.getPosition());
             motorEx.setPower(output * error);
@@ -75,7 +75,7 @@ public class MotorEx extends Motor {
      * @param velocity the velocity in ticks per second
      */
     public void setVelocity(double velocity) {
-        motor.setPower(velocity / ACHIEVABLE_MAX_TICKS_PER_SECOND);
+        set(velocity / ACHIEVABLE_MAX_TICKS_PER_SECOND);
     }
 
     /**


### PR DESCRIPTION
# Improve MotorEx Velocity and Motor Configuration Type

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Feature

Adds a buffer to the motors for velocity PID mode.
In `MotorEx`, setting the velocity now calls `set()` and `set()` calls `setPower()` for `VelocityControl`.
Streamlines the constructors and sets the RPM and CPR of the motor in the configuration type for the third constructor.

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__