### PR TITLE
Remove normalization from AngleUnit in SimpleServo

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
@@ -121,10 +121,7 @@ public class SimpleServo implements ServoEx {
     }
 
     private double fromRadians(double angle, AngleUnit angleUnit) {
-        if (angleUnit == AngleUnit.DEGREES) {
-            return Math.toDegrees(angle);
-        }
-        return angle;
+        return angleUnit == AngleUnit.DEGREES ? Math.toDegrees(angle) : angle;
     }
 
 }

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
@@ -19,8 +19,8 @@ public class SimpleServo implements ServoEx {
     public SimpleServo(HardwareMap hw, String servoName, double minAngle, double maxAngle, AngleUnit angleUnit) {
         servo = hw.get(Servo.class, servoName);
 
-        this.minAngle = angleUnit.toRadians(maxAngle);
-        this.maxAngle = angleUnit.toRadians(minAngle);
+        this.minAngle = toRadians(maxAngle, angleUnit);
+        this.maxAngle = toRadians(minAngle, angleUnit);
     }
 
     public SimpleServo(HardwareMap hw, String servoName, double minAngle, double maxAngle) {
@@ -40,7 +40,7 @@ public class SimpleServo implements ServoEx {
 
     @Override
     public void turnToAngle(double angle, AngleUnit angleUnit) {
-        double angleRadians = Range.clip(angleUnit.toRadians(angle), minAngle, maxAngle);
+        double angleRadians = Range.clip(toRadians(angle, angleUnit), minAngle, maxAngle);
         setPosition((angleRadians - minAngle) / (getAngleRange(AngleUnit.RADIANS)));
     }
 
@@ -62,8 +62,8 @@ public class SimpleServo implements ServoEx {
 
     @Override
     public void setRange(double min, double max, AngleUnit angleUnit) {
-        this.minAngle = angleUnit.toRadians(min);
-        this.maxAngle = angleUnit.toRadians(max);
+        this.minAngle = toRadians(min, angleUnit);
+        this.maxAngle = toRadians(max, angleUnit);
     }
 
     @Override
@@ -88,7 +88,7 @@ public class SimpleServo implements ServoEx {
 
     @Override
     public double getAngle(AngleUnit angleUnit) {
-        return getPosition() * getAngleRange(angleUnit) + angleUnit.fromRadians(minAngle);
+        return getPosition() * getAngleRange(angleUnit) + fromRadians(minAngle, angleUnit);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class SimpleServo implements ServoEx {
     }
 
     public double getAngleRange(AngleUnit angleUnit) {
-        return angleUnit.fromRadians(maxAngle - minAngle);
+        return fromRadians(maxAngle - minAngle, angleUnit);
     }
 
     public double getAngleRange() {
@@ -114,6 +114,20 @@ public class SimpleServo implements ServoEx {
         String port = Integer.toString(servo.getPortNumber());
         String controller = servo.getController().toString();
         return "SimpleServo: " + port + "; " + controller;
+    }
+    
+    private double toRadians(double angle, AngleUnit angleUnit) {
+        if (angleUnit == AngleUnit.DEGREES) {
+            return Math.toRadians(angle);
+        }
+        return angle;
+    }
+
+    private double fromRadians(double angle, AngleUnit angleUnit) {
+        if (angleUnit == AngleUnit.DEGREES) {
+            return Math.toDegrees(angle);
+        }
+        return angle;
     }
 
 }

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
@@ -117,10 +117,7 @@ public class SimpleServo implements ServoEx {
     }
     
     private double toRadians(double angle, AngleUnit angleUnit) {
-        if (angleUnit == AngleUnit.DEGREES) {
-            return Math.toRadians(angle);
-        }
-        return angle;
+        return angleUnit == AngleUnit.DEGREES ? Math.toRadians(angle) : angle;
     }
 
     private double fromRadians(double angle, AngleUnit angleUnit) {


### PR DESCRIPTION
# Pull Requests

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Fix
As @JIceberg pointed out, it seems that AngleUnit methods perform a -180 to 180 normalization which can be a problem for servos which go from beyond that limit. There’s a workaround way for fixing this by doing a range of i.e -90 to 180 degrees for a servo with a range of 0 to 270 (like the rev servos), but it’s less intuitive for the user, which is the reason for this internal change.

This PR uses a custom internal method to perform the conversions with the AngleUnit enum without the mentioned normalization.

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__