### PR TITLE
Fix Reset Encoder on Reversed Direction

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -95,7 +95,7 @@ public class Motor implements HardwareDevice {
                 lastPosition = m_position.get();
                 lastTimeStamp = currentTime;
             }
-            return direction.getMultiplier() * (currentPosition - resetVal);
+            return direction.getMultiplier() * currentPosition - resetVal;
         }
 
         /**

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -513,7 +513,7 @@ public class Motor implements HardwareDevice {
      * motor.
      */
     public void stopMotor() {
-        set(0);
+        motor.setPower(0);
     }
 
 }


### PR DESCRIPTION
# Fix Reset Encoder on Reversed Direction

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Fix - changes the way the multiplier is engaged so the resetVal is independent of that flip in direction

## Did this PR introduce a breaking change?
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__