### PR TITLE
Update SDK Dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,13 +56,12 @@ dependencies {
     testImplementation('org.mockito:mockito-core:3.5.13')
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.0"
 
-    compileOnly 'org.firstinspires.ftc:Inspection:6.2.1'
-    compileOnly 'org.firstinspires.ftc:Blocks:6.2.1'
-    compileOnly 'org.firstinspires.ftc:RobotCore:6.2.1'
-    testImplementation 'org.firstinspires.ftc:RobotCore:6.2.1'
-    compileOnly 'org.firstinspires.ftc:RobotServer:6.2.1'
-    compileOnly 'org.firstinspires.ftc:Hardware:6.2.1'
-    compileOnly 'org.firstinspires.ftc:FtcCommon:6.2.1'
+    compileOnly 'org.firstinspires.ftc:Inspection:7.0.0'
+    compileOnly 'org.firstinspires.ftc:RobotCore:7.0.0'
+    testImplementation 'org.firstinspires.ftc:RobotCore:7.0.0'
+    compileOnly 'org.firstinspires.ftc:RobotServer:7.0.0'
+    compileOnly 'org.firstinspires.ftc:Hardware:7.0.0'
+    compileOnly 'org.firstinspires.ftc:FtcCommon:7.0.0'
     compileOnly 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/core/dependencies.gradle
+++ b/core/dependencies.gradle
@@ -1,12 +1,11 @@
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compileOnly 'org.firstinspires.ftc:Inspection:6.2.1'
-    compileOnly 'org.firstinspires.ftc:Blocks:6.2.1'
-    compileOnly 'org.firstinspires.ftc:RobotCore:6.2.1'
-    compileOnly 'org.firstinspires.ftc:RobotServer:6.2.1'
-    compileOnly 'org.firstinspires.ftc:Hardware:6.2.1'
-    compileOnly 'org.firstinspires.ftc:FtcCommon:6.2.1'
+    compileOnly 'org.firstinspires.ftc:Inspection:7.0.0'
+    compileOnly 'org.firstinspires.ftc:RobotCore:7.0.0'
+    compileOnly 'org.firstinspires.ftc:RobotServer:7.0.0'
+    compileOnly 'org.firstinspires.ftc:Hardware:7.0.0'
+    compileOnly 'org.firstinspires.ftc:FtcCommon:7.0.0'
     compileOnly 'androidx.appcompat:appcompat:1.2.0'
 }
 


### PR DESCRIPTION
# Update SDK Dependencies

Updates the SDK version from 6.2 (maven migrate) to 7.0 (Freight Frenzy seasonal release)

## What kind of change does this PR introduce?
* Feature

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
Depends - on the user end, this should not impact anything. On our end, there might be something changed in the SDK that does in fact produce a breaking change.

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__