### PR TITLE
Introduce Rate Feature to Motor Encoders

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -106,7 +106,7 @@ public class Motor implements HardwareDevice {
         }
 
         /**
-         * @return the velocity of the encoder adjusted to account for the distane per pulse
+         * @return the velocity of the encoder adjusted to account for the distance per pulse
          */
         public double getRate() {
             return dpp * getVelocity();

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -106,6 +106,13 @@ public class Motor implements HardwareDevice {
         }
 
         /**
+         * @return the velocity of the encoder adjusted to account for the distane per pulse
+         */
+        public double getRate() {
+            return dpp * getVelocity();
+        }
+
+        /**
          * Resets the encoder without having to stop the motor.
          */
         public void reset() {
@@ -311,6 +318,13 @@ public class Motor implements HardwareDevice {
      */
     public double getDistance() {
         return encoder.getDistance();
+    }
+
+    /**
+     * @return the rate of the encoder
+     */
+    public double getRate() {
+        return encoder.getRate();
     }
 
     /**

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorGroup.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorGroup.java
@@ -16,15 +16,17 @@ import java.util.stream.Collectors;
 public class MotorGroup extends Motor implements Iterable<Motor> {
 
     private final Motor[] group;
-    private boolean isInverted;
 
     /**
      * Create a new MotorGroup with the provided Motors.
      *
-     * @param motors The motors to add.
+     * @param leader    The leader motor.
+     * @param followers The follower motors which follow the leader motor's protocols.
      */
-    public MotorGroup(Motor... motors) {
-        group = motors;
+    public MotorGroup(@NonNull Motor leader, Motor... followers) {
+        group = new Motor[followers.length + 1];
+        group[0] = leader;
+        System.arraycopy(followers, 0, group, 1, followers.length);
     }
 
     /**
@@ -36,7 +38,7 @@ public class MotorGroup extends Motor implements Iterable<Motor> {
     public void set(double speed) {
         group[0].set(speed);
         for (int i = 1; i < group.length; i++) {
-            group[i].set(isInverted ? -group[0].get() : group[0].get());
+            group[i].set(group[0].get());
         }
     }
 
@@ -63,11 +65,12 @@ public class MotorGroup extends Motor implements Iterable<Motor> {
     }
 
     /**
-     * @return All current velocities of the motors in the group
+     * @return All current velocities of the motors in the group in units of distance
+     * per second which is by default ticks / second
      */
     public List<Double> getVelocities() {
         return Arrays.stream(group)
-                .map(Motor::getCorrectedVelocity)
+                .map(Motor::getRate)
                 .collect(Collectors.toList());
     }
 
@@ -160,7 +163,7 @@ public class MotorGroup extends Motor implements Iterable<Motor> {
      */
     @Override
     public boolean getInverted() {
-        return isInverted;
+        return group[0].getInverted();
     }
 
     /**
@@ -171,7 +174,9 @@ public class MotorGroup extends Motor implements Iterable<Motor> {
      */
     @Override
     public void setInverted(boolean isInverted) {
-        this.isInverted = isInverted;
+        for (Motor motor : group) {
+            motor.setInverted(isInverted);
+        }
     }
 
     /**


### PR DESCRIPTION
# Introduce Rate Feature to Motor Encoders

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Feature

This PR improves upon the motor velocity obtained from the built-in encoder class. The inversion meaning of the `MotorGroup` class has been changed to better suit these changes. `Motor.Encoder` now offers a `getRate()` method which returns the velocity of the encoder in units of distance per second, which is dependent on the defined distance per pulse. By default this is 1, so the output is typically in ticks per second.

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
* Yes, please list breaking changes

The breaking changes are:
* change in inversion scheme for `MotorGroup`
* changes the output of `getVelocities()` in `MotorGroup` to use `getRate` by default

Some questions I have: should `getRate()` internally call `getCorrectedVelocity` instead of `getVelocity` or even `getRawVelocity`? Would love to hear your opinions on this.

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__