### PR TITLE
SimpleServo min/maxAngle assignments flipped

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
@@ -19,8 +19,8 @@ public class SimpleServo implements ServoEx {
     public SimpleServo(HardwareMap hw, String servoName, double minAngle, double maxAngle, AngleUnit angleUnit) {
         servo = hw.get(Servo.class, servoName);
 
-        this.minAngle = toRadians(maxAngle, angleUnit);
-        this.maxAngle = toRadians(minAngle, angleUnit);
+        this.minAngle = toRadians(minAngle, angleUnit);
+        this.maxAngle = toRadians(maxAngle, angleUnit);
     }
 
     public SimpleServo(HardwareMap hw, String servoName, double minAngle, double maxAngle) {


### PR DESCRIPTION
maxAngle going in to minAngle member instead of maxAngle. Same for minAngle.

This is a fix.  This broke all of the math since max was really min and min was max.
