### PR TITLE
Min and Max flipped. Clarify AngleUnit type in parameter name

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/SimpleServo.java
@@ -23,8 +23,8 @@ public class SimpleServo implements ServoEx {
         this.maxAngle = toRadians(minAngle, angleUnit);
     }
 
-    public SimpleServo(HardwareMap hw, String servoName, double minAngle, double maxAngle) {
-        this(hw, servoName, maxAngle, minAngle, AngleUnit.DEGREES);
+    public SimpleServo(HardwareMap hw, String servoName, double minDegree, double maxDegree) {
+        this(hw, servoName, minDegree, maxDegree, AngleUnit.DEGREES);
     }
 
     @Override


### PR DESCRIPTION
Fix: min and max arguments flipped on call to constructor. 

Codestyle: Consider renaming parameter to minDegree and maxDegree to clarify to caller that AngleUnit.DEGREES is assumed.


# Pull Requests

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Fix
* Codestyle

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__