### PR TITLE
Update Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: JIceberg, pranavavva
+assignees: JIceberg
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,8 +2,8 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: backend, documentation, enhancement, hardware
-assignees: JIceberg, codeNinjaDev, Lunerwalker2
+labels: ''
+assignees: JIceberg
 
 ---
 


### PR DESCRIPTION
# Update Issue Templates

Updated issue templates because they only really need to assign me and then I can assign people as needed. The feature request template added the `hardware` label for some reason, which was unnecessary, so I removed that.