### PR TITLE
Remove Acceleration from RevIMU

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/RevIMU.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/RevIMU.java
@@ -54,11 +54,9 @@ public class RevIMU extends GyroEx {
     public void init() {
         BNO055IMU.Parameters parameters = new BNO055IMU.Parameters();
         parameters.angleUnit = BNO055IMU.AngleUnit.DEGREES;
-        parameters.accelUnit = BNO055IMU.AccelUnit.METERS_PERSEC_PERSEC;
         parameters.calibrationDataFile = "BNO055IMUCalibration.json"; // see the calibration sample opmode
         parameters.loggingEnabled = true;
         parameters.loggingTag = "IMU";
-        parameters.accelerationIntegrationAlgorithm = new JustLoggingAccelerationIntegrator();
 
         init(parameters);
     }


### PR DESCRIPTION
# Remove Acceleration from `RevIMU`

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Feature

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
* No (?)

@NoahAndrews can probably answer if removing the logging will result in issues if the user was previously calling `startAccelerationIntegration()`.

Resolves #197 

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__