### PR TITLE
Update EasyOpenCV to v1.5.2 to work with SDK 8.0

### DIFF
--- a/core/vision/build.gradle
+++ b/core/vision/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven'
 
 dependencies {
-    api 'org.openftc:easyopencv:1.5.1'
+    api 'org.openftc:easyopencv:1.5.2'
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }


### PR DESCRIPTION
# Update EasyOpenCV to v1.5.2

The currently published version of FTCLib uses EasyOpenCV v1.5.1. This version is known not to work with FTC SDK 8.0 which is being used for this season. Updating this library would cause no breaking API changes except to support the new version of the SDK.

See OpenFTC/EasyOpenCV#50 for reference of the issue at hand. I can also confirm that this update works perfectly on our robot.

## What kind of change does this PR introduce?
* Fix

## Did this PR introduce a breaking change?
* Yes
Once merged, this PR would make FTCLib incompatible with versions earlier than v8.0.0.

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__