### PR TITLE
Made GamepadEx#wasJustPressed easier to use.

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/gamepad/GamepadEx.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/gamepad/GamepadEx.java
@@ -44,7 +44,7 @@ public class GamepadEx {
 
     /**
      * @param button the button object
-     * @return the boolean value as to whether the button is active or not
+     * @return the boolean value whether the button is active or not
      */
     public boolean getButton(Button button) {
         boolean buttonValue = false;
@@ -152,6 +152,7 @@ public class GamepadEx {
      * @return if the button was just pressed
      */
     public boolean wasJustPressed(Button button) {
+        buttonReaders.get(button).readValue();
         return buttonReaders.get(button).wasJustPressed();
     }
 
@@ -162,6 +163,7 @@ public class GamepadEx {
      * @return if the button was just released
      */
     public boolean wasJustReleased(Button button) {
+        buttonReaders.get(button).readValue();
         return buttonReaders.get(button).wasJustReleased();
     }
 
@@ -192,6 +194,7 @@ public class GamepadEx {
      * @return if the button's state has just changed
      */
     public boolean stateJustChanged(Button button) {
+        buttonReaders.get(button).readValue();
         return buttonReaders.get(button).stateJustChanged();
     }
 

--- a/core/src/test/java/com/arcrobotics/ftclib/gamepad/GamepadButtonTest.java
+++ b/core/src/test/java/com/arcrobotics/ftclib/gamepad/GamepadButtonTest.java
@@ -54,16 +54,9 @@ public class GamepadButtonTest {
         BooleanSupplier wasJustPressed = () -> gamepadEx.wasJustPressed(GamepadKeys.Button.A);
         assertFalse(wasJustPressed.getAsBoolean());
         myGamepad.a = true;
-        assertFalse(wasJustPressed.getAsBoolean());
-        gamepadEx.readButtons();
         assertTrue(wasJustPressed.getAsBoolean());
-        myGamepad.a = true;
-        assertTrue(wasJustPressed.getAsBoolean());
-        gamepadEx.readButtons();
         assertFalse(wasJustPressed.getAsBoolean());
         myGamepad.a = false;
-        assertFalse(wasJustPressed.getAsBoolean());
-        gamepadEx.readButtons();
         assertFalse(wasJustPressed.getAsBoolean());
     }
 


### PR DESCRIPTION
# Pull Requests

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Codestyle
* Refactor

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__

Hi!
my team uses this library and we had bad times understanding how to properly use the `GamepadEx#wasJustPressed` function because it wasn't clear that we need to call `ButtonReader#readValue` before calling `GamepadEx#wasJustPressed`.
My change should not break backward compatibility.
On the way I also fixed a little typo :)

Thanks,
Adar