### PR TITLE
Add Hard Encoder Reset

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/Motor.java
@@ -335,10 +335,19 @@ public class Motor implements HardwareDevice {
     }
 
     /**
-     * Resets the encoder.
+     * Resets the external encoder wrapper value.
      */
     public void resetEncoder() {
         encoder.reset();
+    }
+
+    /**
+     * Resets the internal position of the motor.
+     */
+    public void stopAndResetEncoder() {
+        encoder.resetVal = 0;
+        motor.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        motor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
     }
 
     /**

--- a/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorGroup.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/hardware/motors/MotorGroup.java
@@ -113,9 +113,12 @@ public class MotorGroup extends Motor implements Iterable<Motor> {
 
     @Override
     public void resetEncoder() {
-        for (Motor motor : group) {
-            motor.resetEncoder();
-        }
+        group[0].resetEncoder();
+    }
+
+    @Override
+    public void stopAndResetEncoder() {
+        group[0].stopAndResetEncoder();
     }
 
     @Override


### PR DESCRIPTION
# Add Hard Encoder Reset

Please note that we accept pull requests from anyone, but that does not mean it will be merged.

## What kind of change does this PR introduce?
* Feature

The current motor wrapper doesn't allow for a hard reset of the hardware position, which can lead to potential problems and as of now the only solution is to call to the available DcMotor and perform a STOP_AND_RESET. This should be an existing feature instead.

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
* No

__Please make sure your PR satisfies the requirements of [the contributing page](CONTRIBUTING.md)__