### PR TITLE
Mecanum Kinematics: remove scaling factor to match w wpilib

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/kinematics/wpilibkinematics/MecanumDriveKinematics.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/kinematics/wpilibkinematics/MecanumDriveKinematics.java
@@ -165,6 +165,5 @@ public class MecanumDriveKinematics {
         m_inverseKinematics.setRow(1, 0, 1, 1, fr.getX() - fr.getY());
         m_inverseKinematics.setRow(2, 0, 1, 1, rl.getX() - rl.getY());
         m_inverseKinematics.setRow(3, 0, 1, -1, -(rr.getX() + rr.getY()));
-        m_inverseKinematics = m_inverseKinematics.scale(1.0 / Math.sqrt(2));
     }
 }


### PR DESCRIPTION
WPIlib removed the scaling factor on the inverse kinematics back in 2022: 

https://github.com/wpilibsuite/allwpilib/blob/d5ed9fb859f29dd677daeac981061e56440b941b/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveKinematics.java#L192

This should match that better