### PR TITLE
fix: Double ending issue in ParallelRaceGroup

### DIFF
--- a/core/src/main/java/com/arcrobotics/ftclib/command/ParallelRaceGroup.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/command/ParallelRaceGroup.java
@@ -72,7 +72,6 @@ public class ParallelRaceGroup extends CommandGroupBase {
             command.execute();
             if (command.isFinished()) {
                 m_finished = true;
-                command.end(false);
             }
         }
     }

--- a/core/src/main/java/com/arcrobotics/ftclib/command/SequentialCommandGroup.java
+++ b/core/src/main/java/com/arcrobotics/ftclib/command/SequentialCommandGroup.java
@@ -66,6 +66,9 @@ public class SequentialCommandGroup extends CommandGroupBase {
         if (m_commands.isEmpty()) {
             return;
         }
+        if (m_currentCommandIndex == -1) {
+            return;
+        }
 
         Command currentCommand = m_commands.get(m_currentCommandIndex);
 
@@ -81,6 +84,9 @@ public class SequentialCommandGroup extends CommandGroupBase {
 
     @Override
     public void end(boolean interrupted) {
+        if (m_currentCommandIndex == -1) {
+            return;
+        }
         if (interrupted && !m_commands.isEmpty()) {
             m_commands.get(m_currentCommandIndex).end(true);
         }


### PR DESCRIPTION
This PR fixes a bug in `ParallelRaceGroup` that ends one of the commands twice. The `end` method in `SequentialCommandGroup` updates its array index to `-1` when called, so if the `end` method in `SequentialCommandGroup` is called twice, an array out of bounds error occurs. With the current code, if a `SequentialCommandGroup` finishes first in a `ParallelRaceGroup`, a fatal error occurs, so this PR fixes it (without any breaking changes).